### PR TITLE
Update rss crate version dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syndication"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Tom Shen <tom@shen.io>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/tomshen/rust-syndication"
@@ -10,4 +10,4 @@ exclude = ["test-data/*"]
 
 [dependencies]
 atom_syndication = "0.1"
-rss = "0.2"
+rss = "0.3"


### PR DESCRIPTION
Also bump this crate's version to 0.2.0, because rss's types are exposed in syndication's public API, which will force clients to update rss if they depend on it and if they need to interoperate with syndication to update.

[breaking-change]
