### PR TITLE
Update atom crate version dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syndication"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Tom Shen <tom@shen.io>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/tomshen/rust-syndication"
@@ -9,5 +9,5 @@ keywords = ["atom", "blog", "feed", "rss", "syndication"]
 exclude = ["test-data/*"]
 
 [dependencies]
-atom_syndication = "0.1"
+atom_syndication = "0.2"
 rss = "0.3"


### PR DESCRIPTION
It's me again! :smile:

Update the version dependency for atom to 0.2, which contains many changes; in particular it no longer panics when parsing an invalid Atom feed. It also contains a breaking change, which is why the version was bumped to 0.2.

Also bump this crate's version to 0.3.0, because atom's types are exposed in syndication's public API, which will force clients to update atom if they depend on it and if they need to interoperate with syndication.

[breaking-change]

cc @porglezomp (you may want to update https://github.com/tomshen/rust-syndication/pull/5 after this is merged)
