### PR TITLE
Fix `Reading` examle code

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ let atom_str = r#"
 "#;
 
 match atom_str.parse::<Feed>().unwrap() {
-    Feed::Atom(atom_feed) => println!("Atom feed first entry: {:?}", atom_feed.entries[0].title),
+    Feed::Atom(atom_feed) => println!("Atom feed first entry: {:?}", atom_feed.entries()[0].title()),
     _ => {}
 };
 
@@ -46,7 +46,7 @@ let rss_str = r#"
 
 match rss_str.parse::<Feed>().unwrap() {
     Feed::RSS(rss_feed) => println!("RSS feed first entry: {:?}",
-        rss_feed.items[0].title),
+        rss_feed.items[0].title()),
     _ => {}
 };
 ```


### PR DESCRIPTION
The current example code has the following compile error.

```
error[E0616]: field `entries` of struct `atom_syndication::feed::Feed` is private
  --> src/main.rs:20:63
   |
20 |             println!("Atom feed first entry: {:?}", atom_feed.entries[0].title)
   |                                                               ^^^^^^^ private field
   |

error[E0616]: field `title` of struct `atom_syndication::entry::Entry` is private
  --> src/main.rs:20:74
   |
20 |             println!("Atom feed first entry: {:?}", atom_feed.entries[0].title)
   |                                                                          ^^^^^ private field
```

This patch fixed that issue and changed it to work.