### PR TITLE
Update dependencies and address clippy lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,5 @@ keywords = ["atom", "blog", "feed", "rss", "syndication"]
 exclude = ["test-data/*"]
 
 [dependencies]
-atom_syndication = "0.11"
+atom_syndication = "0.12"
 rss = "2.0"

--- a/examples/read.rs
+++ b/examples/read.rs
@@ -17,12 +17,11 @@ fn main() {
     </feed>
     "#;
 
-    match atom_str.parse::<Feed>().unwrap() {
-        Feed::Atom(atom_feed) => println!(
+    if let Feed::Atom(atom_feed) = atom_str.parse::<Feed>().unwrap() {
+        println!(
             "Atom feed first entry: {:?}",
             atom_feed.entries()[0].title()
-        ),
-        _ => {}
+        );
     };
 
     let rss_str = r#"
@@ -41,8 +40,7 @@ fn main() {
     </rss>
     "#;
 
-    match rss_str.parse::<Feed>().unwrap() {
-        Feed::RSS(rss_feed) => println!("RSS feed first entry: {:?}", rss_feed.items()[0].title()),
-        _ => {}
+    if let Feed::RSS(rss_feed) = rss_str.parse::<Feed>().unwrap() {
+        println!("RSS feed first entry: {:?}", rss_feed.items()[0].title());
     };
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,8 +23,8 @@ impl FromStr for Feed {
 impl ToString for Feed {
     fn to_string(&self) -> String {
         match self {
-            &Feed::Atom(ref atom_feed) => atom_feed.to_string(),
-            &Feed::RSS(ref rss_channel) => rss_channel.to_string(),
+            Feed::Atom(atom_feed) => atom_feed.to_string(),
+            Feed::RSS(rss_channel) => rss_channel.to_string(),
         }
     }
 }
@@ -44,7 +44,7 @@ mod test {
         let mut atom_string = String::new();
         file.read_to_string(&mut atom_string).unwrap();
         let feed = Feed::from_str(&atom_string).unwrap();
-        assert!(feed.to_string().len() > 0);
+        assert!(!feed.to_string().is_empty());
     }
 
     // Source: https://github.com/frewsxcv/rust-rss/blob/master/src/lib.rs
@@ -54,7 +54,7 @@ mod test {
         let mut rss_string = String::new();
         file.read_to_string(&mut rss_string).unwrap();
         let rss = Feed::from_str(&rss_string).unwrap();
-        assert!(rss.to_string().len() > 0);
+        assert!(!rss.to_string().is_empty());
     }
 
     // Source: https://github.com/vtduncan/rust-atom/blob/master/src/lib.rs
@@ -66,11 +66,11 @@ mod test {
 
         let entry = atom_syndication::EntryBuilder::default()
             .title("My first post!")
-            .content(
+            .content(Some(
                 atom_syndication::ContentBuilder::default()
-                    .value("This is my first post".to_string())
+                    .value(Some("This is my first post".to_string()))
                     .build(),
-            )
+            ))
             .build();
 
         let feed = atom_syndication::FeedBuilder::default()
@@ -86,9 +86,9 @@ mod test {
     #[test]
     fn test_rss_to_string() {
         let item = rss::ItemBuilder::default()
-            .title("My first post!".to_string())
-            .link("http://myblog.com/post1".to_string())
-            .description("This is my first post".to_string())
+            .title(Some("My first post!".to_string()))
+            .link(Some("http://myblog.com/post1".to_string()))
+            .description(Some("This is my first post".to_string()))
             .build();
 
         let channel = rss::ChannelBuilder::default()


### PR DESCRIPTION
style: fix all `clippy` lints

Suggestions were found by running

    cargo clippy --all-targets --all-features -- -D warnings

using

    clippy 0.1.69 (84c898d 2023-04-16)

---

build(deps): update `atom_syndication` to v0.12
