### PR TITLE
Update atom_syndication to 0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,5 @@ keywords = ["atom", "blog", "feed", "rss", "syndication"]
 exclude = ["test-data/*"]
 
 [dependencies]
-atom_syndication = "0.11"
+atom_syndication = "0.12"
 rss = "2.0"


### PR DESCRIPTION
Currently, `cargo check` command prints following warning:

```
warning: the following packages contain code that will be rejected by a future version of Rust: quick-xml v0.12.4, quick-xml v0.20.0
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 1`
```

This PR updates atom_syndication to [0.12 version that depends on quick_xml v0.30](https://github.com/rust-syndication/atom/blob/master/CHANGELOG.md#0122---2023-07-26).